### PR TITLE
fix peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React component library for building inertial touch applications.",
   "main": "lib/ReactTouch.js",
   "peerDependencies": {
-    "react": "~0.9"
+    "react": ">=0.9.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Generally peerDepencencies should always be written with a `>=` unless you know it won't work with later versions.
