### PR TITLE
Mousewheel support

### DIFF
--- a/src/primitives/TouchableArea.js
+++ b/src/primitives/TouchableArea.js
@@ -3,11 +3,76 @@
 var React = require('react');
 
 var TouchableArea = React.createClass({
+  getInitialState: function() {
+    return {
+      cumulativeScroll: {x:0, y:0},
+      gestureStart: {x:0, y:0},
+      isMouseWheeling: false,
+    };
+  },
+
   getDefaultProps: function() {
     return {
       component: React.DOM.div,
       touchable: true
     };
+  },
+
+  handleWheel: function(e) {
+    if (!this.props.scroller || !this.props.touchable) {
+      return;
+    }
+
+    if (e.timeStamp) {
+      this.state.lastTimeStamp = e.timeStamp;
+    }
+
+    var self = this;
+    var timeStamp = e.timeStamp || this.state.lastTimeStamp;
+    var scrollDeltaX, scrollDeltaY;
+    if (!this.state.isMouseWheeling) {
+      this.state.isMouseWheeling = true;
+      this.state.cumulativeScroll.x = 0;
+      this.state.cumulativeScroll.y = 0;
+
+      // Start a scroll event
+      this.props.scroller.doTouchStart([{
+        pageX: 0,
+        pageY: 0,
+      }], e.timeStamp);
+      return;
+    }
+
+    // Convert the scrollwheel values to a scroll value
+    scrollDeltaX = e.deltaX / 2;
+    scrollDeltaY = -e.deltaY / 2;
+
+    // If the scroller is constrained to an x axis, convert y scroll to allow single-axis scroll
+    // wheels to scroll constrained content.
+    if (this.props.scrollAxis === 'x') {
+      scrollDeltaX = scrollDeltaY;
+      scrollDeltaY = 0;
+    }
+
+    this.state.cumulativeScroll.x = Math.round(this.state.cumulativeScroll.x + scrollDeltaX);
+    this.state.cumulativeScroll.y = Math.round(this.state.cumulativeScroll.y + scrollDeltaY);
+
+    var pageX = -this.state.gestureStart.x + this.state.cumulativeScroll.x;
+    var pageY = this.state.gestureStart.y + this.state.cumulativeScroll.y;
+
+    this.props.scroller.doTouchMove([{pageX: pageX, pageY: pageY}], timeStamp);
+
+    //_updateScroll(_gestureStart.x + _cumulativeScroll.x, _gestureStart.y + _cumulativeScroll.y, event.timeStamp, event);
+
+    // End scrolling state
+    if (this.state._scrollWheelEndDebouncer) {
+      clearTimeout(this.state._scrollWheelEndDebouncer);
+    }
+    this.state._scrollWheelEndDebouncer = setTimeout(function () {
+      self.props.scroller.doTouchEnd(timeStamp);
+      //_releaseInputCapture();
+      self.state.isMouseWheeling = false;
+    }, 300);
   },
 
   handleTouchStart: function(e) {
@@ -41,6 +106,7 @@ var TouchableArea = React.createClass({
     var component = this.props.component;
     return this.transferPropsTo(
       <component
+        onWheel={this.handleWheel}
         onTouchStart={this.handleTouchStart}
         onTouchMove={this.handleTouchMove}
         onTouchEnd={this.handleTouchEnd}


### PR DESCRIPTION
Add experimental mousewheel support.

This is a simplistic port of [ftscroller](https://github.com/ftlabs/ftscroller)’s mousewheel support.
https://github.com/ftlabs/ftscroller/blob/master/lib/ftscroller.js#L2255-L2323

As such, it currently still suffers from extra delayed mousewheel bounce backs on platforms that have intertial scrolling due to mousewheel events firing throughout the native inertial scroll behavior.
